### PR TITLE
Jenkins: List all projects

### DIFF
--- a/src/services/jenkins.js
+++ b/src/services/jenkins.js
@@ -6,7 +6,7 @@ const feed = require('./feed')
 
 async function getProjects ({ url, project, token, user }) {
   const service = 'jenkins'
-  const uri = new URL('/cc.xml', `${url}`)
+  const uri = new URL('/cc.xml?recursive', `${url}`)
   const auth = { user, pass: token }
   const projects = await feed.getProjects(uri.href, { service, auth })
   if (project) {


### PR DESCRIPTION
Some jenkins instances are organized in nested jobs. This change makes the cc.xml respond with the full list.